### PR TITLE
Adaptive Rate Nonlinear Model: default OFF

### DIFF
--- a/Settings.bundle/Root.plist
+++ b/Settings.bundle/Root.plist
@@ -14,7 +14,7 @@
 			<key>Key</key>
 			<string>adaptiveRateNonlinear_enabled</string>
 			<key>DefaultValue</key>
-			<true/>
+			<false/>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Changes the default app setting for Adaptive Rate Nonlinear Model to OFF