### PR TITLE
Release FreeAPS v2.2 (201)

### DIFF
--- a/Common/Extensions/NSBundle.swift
+++ b/Common/Extensions/NSBundle.swift
@@ -65,4 +65,16 @@ extension Bundle {
     var xcodeVersion: String? {
         return object(forInfoDictionaryKey: "com-loopkit-Loop-xcode-version") as? String
     }
+    
+    var profileExpiration: Date? {
+        return object(forInfoDictionaryKey: "com-loopkit-Loop-profile-expiration") as? Date
+    }
+
+    var profileExpirationString: String {
+        if let profileExpiration = profileExpiration {
+            return "\(profileExpiration)"
+        } else {
+            return "N/A"
+        }
+    }
 }

--- a/DoseMathTests/Info.plist
+++ b/DoseMathTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>176</string>
+	<string>201</string>
 </dict>
 </plist>

--- a/Learn/Info.plist
+++ b/Learn/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>MainAppBundleIdentifier</key>
-	<string>$(MAIN_APP_BUNDLE_IDENTIFIER)</string>
 	<key>AppGroupIdentifier</key>
 	<string>$(APP_GROUP_IDENTIFIER)</string>
 	<key>CFBundleDevelopmentRegion</key>
@@ -19,11 +17,13 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
-	<string>176</string>
+	<string>201</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>MainAppBundleIdentifier</key>
+	<string>$(MAIN_APP_BUNDLE_IDENTIFIER)</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Meal data from the Health database is used to determine glucose effects. Glucose data from the Health database is used for graphing and momentum calculation. Sleep data from the Health database is used to optimize delivery of Apple Watch complication updates during the time you are awake.</string>
 	<key>UILaunchStoryboardName</key>

--- a/Loop Status Extension/Info.plist
+++ b/Loop Status Extension/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
-	<string>176</string>
+	<string>201</string>
 	<key>MainAppBundleIdentifier</key>
 	<string>$(MAIN_APP_BUNDLE_IDENTIFIER)</string>
 	<key>NSExtension</key>

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -3471,7 +3471,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(APPICON_NAME)";
 				CODE_SIGN_ENTITLEMENTS = Loop/Loop.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = BA7ZHP4963;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Loop/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -3493,7 +3493,7 @@
 				CODE_SIGN_ENTITLEMENTS = Loop/Loop.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = BA7ZHP4963;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Loop/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -3513,7 +3513,7 @@
 				CODE_SIGN_ENTITLEMENTS = "WatchApp Extension/WatchApp Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = BA7ZHP4963;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/watchOS";
 				INFOPLIST_FILE = "WatchApp Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
@@ -3538,7 +3538,7 @@
 				CODE_SIGN_ENTITLEMENTS = "WatchApp Extension/WatchApp Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = BA7ZHP4963;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/watchOS";
 				INFOPLIST_FILE = "WatchApp Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
@@ -3561,7 +3561,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(APPICON_NAME)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = BA7ZHP4963;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/watchOS";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
@@ -3584,7 +3584,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(APPICON_NAME)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = BA7ZHP4963;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/watchOS";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
@@ -3872,7 +3872,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BA7ZHP4963;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "Loop Status Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -3896,7 +3896,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BA7ZHP4963;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "Loop Status Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -2585,6 +2585,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Capture Build Details";
 			outputFileListPaths = (

--- a/Loop/Base.lproj/Localizable.strings
+++ b/Loop/Base.lproj/Localizable.strings
@@ -49,6 +49,9 @@
 /* Subtitle of Rapid-Acting – Adult preset */
 "A model based on the published absorption of Humalog, Novolog, and Apidra insulin in adults." = "A model based on the published absorption of Humalog, Novolog, and Apidra insulin in adults.";
 
+/* Subtitle of Lyumjev preset */
+"A model based on the published absorption of Lyumjev insulin." = "A model based on the published absorption of Lyumjev insulin.";
+
 /* Action to copy the recommended Bolus value to the actual Bolus Field */
 "AcceptRecommendedBolus" = "AcceptRecommendedBolus";
 

--- a/Loop/Extensions/InsulinModelSettings+Loop.swift
+++ b/Loop/Extensions/InsulinModelSettings+Loop.swift
@@ -30,6 +30,8 @@ extension ExponentialInsulinModelPreset {
             return NSLocalizedString("Rapid-Acting – Children", comment: "Title of insulin model preset")
         case .fiasp:
             return NSLocalizedString("Fiasp", comment: "Title of insulin model preset")
+        case .lyumjev:
+            return  NSLocalizedString("Lyumjev", comment: "Title of insulin model preset")
         }
     }
 
@@ -41,6 +43,8 @@ extension ExponentialInsulinModelPreset {
             return NSLocalizedString("An adjustment to the adult model based on empirical effects in children.", comment: "Subtitle of Rapid-Acting – Children preset")
         case .fiasp:
             return NSLocalizedString("A model based on the published absorption of Fiasp insulin.", comment: "Subtitle of Fiasp preset")
+        case .lyumjev:
+            return NSLocalizedString("A model based on the published absorption of Lyumjev insulin.", comment: "Subtitle of Lyumjev preset")
         }
     }
 }

--- a/Loop/Info.plist
+++ b/Loop/Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -49,7 +49,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>176</string>
+	<string>201</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
@@ -62,6 +62,8 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -122,8 +124,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>LSSupportsOpeningDocumentsInPlace</key>
-	<false/>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -210,6 +210,7 @@ final class DeviceDataManager {
                 let report = [
                     "## LoopVersion",
                     "* Version: \(Bundle.main.localizedNameAndVersion)",
+                    "* profileExpiration: \(Bundle.main.profileExpirationString)",
                     "* gitRevision: \(Bundle.main.gitRevision ?? "N/A")",
                     "* gitBranch: \(Bundle.main.gitBranch ?? "N/A")",
                     "* sourceRoot: \(Bundle.main.sourceRoot ?? "N/A")",

--- a/Loop/View Controllers/InsulinModelSettingsViewController.swift
+++ b/Loop/View Controllers/InsulinModelSettingsViewController.swift
@@ -62,7 +62,8 @@ class InsulinModelSettingsViewController: ChartsTableViewController, Identifiabl
         WalshInsulinModel(actionDuration: .hours(6)),
         ExponentialInsulinModelPreset.humalogNovologAdult,
         ExponentialInsulinModelPreset.humalogNovologChild,
-        ExponentialInsulinModelPreset.fiasp
+        ExponentialInsulinModelPreset.fiasp,
+        ExponentialInsulinModelPreset.lyumjev
     ]
 
     private var selectedModelIndex: Int? {

--- a/LoopCore/Info.plist
+++ b/LoopCore/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
-	<string>176</string>
+	<string>201</string>
 </dict>
 </plist>

--- a/LoopCore/Insulin/ExponentialInsulinModelPreset.swift
+++ b/LoopCore/Insulin/ExponentialInsulinModelPreset.swift
@@ -12,6 +12,7 @@ public enum ExponentialInsulinModelPreset: String {
     case humalogNovologAdult
     case humalogNovologChild
     case fiasp
+    case lyumjev
 }
 
 
@@ -25,6 +26,8 @@ extension ExponentialInsulinModelPreset {
             return .minutes(360)
         case .fiasp:
             return .minutes(360)
+        case .lyumjev:
+            return .minutes(300)
         }
     }
 
@@ -36,6 +39,8 @@ extension ExponentialInsulinModelPreset {
             return .minutes(65)
         case .fiasp:
             return .minutes(55)
+        case .lyumjev:
+            return .minutes(62)
         }
     }
     
@@ -47,6 +52,8 @@ extension ExponentialInsulinModelPreset {
             return .minutes(10)
         case .fiasp:
             return .minutes(10)
+        case .lyumjev:
+            return .minutes(5)
         }
     }
 

--- a/LoopTests/Info.plist
+++ b/LoopTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>176</string>
+	<string>201</string>
 </dict>
 </plist>

--- a/LoopUI/Info.plist
+++ b/LoopUI/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
-	<string>176</string>
+	<string>201</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Scripts/capture-build-details.sh
+++ b/Scripts/capture-build-details.sh
@@ -5,18 +5,86 @@
 #
 #  Copyright © 2019 LoopKit Authors. All rights reserved.
 
-echo "Gathering build details in ${SRCROOT}"
-cd "${SRCROOT}"
+SCRIPT="$(basename "${0}")"
+SCRIPT_DIRECTORY="$(dirname "${0}")"
 
-plist="${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}"
+error() {
+  echo "ERROR: ${*}" >&2
+  echo "Usage: ${SCRIPT} [-r|--git-source-root git-source-root] [-p|--provisioning-profile-path provisioning-profile-path] [-i|--info-plist-path info-plist-path]" >&2
+  echo "Parameters:" >&2
+  echo "  -r|--git-source-root <git-source-root>                     root location of git repository to gather information from; optional, defaults to \${WORKSPACE_ROOT} if present, otherwise defaults to \${SRCROOT}" >&2
+  echo "  -p|--provisioning-profile-path <provisioning-profile-path> path to the .mobileprovision provisioning profile file to check for expiration; optional, defaults to \${HOME}/Library/MobileDevice/Provisioning Profiles/\${EXPANDED_PROVISIONING_PROFILE}.mobileprovision" >&2
+  echo "  -i|--info-plist-path <info-plist-path>                     path to the Info.plist file to modify; optional, defaults to \${BUILT_PRODUCTS_DIR}/\${INFOPLIST_PATH}" >&2
+  exit 1
+}
+
+warn() {
+  echo "WARN: ${*}" >&2
+}
+
+info() {
+  echo "INFO: ${*}" >&2
+}
+
+git_source_root="${WORKSPACE_ROOT:-${SRCROOT}}"
+info_plist_path="${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}"
+provisioning_profile_path="${HOME}/Library/MobileDevice/Provisioning Profiles/${EXPANDED_PROVISIONING_PROFILE}.mobileprovision"
+xcode_build_version=${XCODE_PRODUCT_BUILD_VERSION:-$(xcodebuild -version | grep version | cut -d ' ' -f 3)}
+while [[ $# -gt 0 ]]
+do
+  case $1 in
+    -r|--git-source-root)
+      git_source_root="${2}"
+      shift 2
+      ;;
+    -i|--info-plist-path)
+      info_plist_path="${2}"
+      shift 2
+      ;;
+    -p|--provisioning-profile-path)
+      provisioning_profile_path="${2}"
+      shift 2
+      ;;
+  esac
+done
+
+if [ ${#} -ne 0 ]; then
+  error "Unexpected arguments: ${*}"
+fi
+
+if [ -z "${git_source_root}" ]; then
+  error "Must provide one of --git-source-root, \${WORKSPACE_ROOT}, or \${SRCROOT}."
+fi
+
+if [ "${info_plist_path}" == "/" -o ! -e "${info_plist_path}" ]; then
+  error "Must provide valid --info-plist-path, or have valid \${BUILT_PRODUCTS_DIR} and \${INFOPLIST_PATH} set."
+fi
+
+info "Gathering build details in ${git_source_root}"
+cd "${git_source_root}"
 
 if [ -e .git ]; then
   rev=$(git rev-parse HEAD)
-  plutil -replace com-loopkit-Loop-git-revision -string ${rev} "${plist}"
-  branch=$(git branch | grep \* | cut -d ' ' -f2-)
-  plutil -replace com-loopkit-Loop-git-branch -string "${branch}" "${plist}"
-fi;
-plutil -replace com-loopkit-Loop-srcroot -string "${SRCROOT}" "${plist}"
-plutil -replace com-loopkit-Loop-build-date -string "$(date)" "${plist}"
-plutil -replace com-loopkit-Loop-xcode-version -string "${XCODE_PRODUCT_BUILD_VERSION}" "${plist}"
+  plutil -replace com-loopkit-Loop-git-revision -string ${rev} "${info_plist_path}"
+  branch=$(git branch --show-current)
+  if [ -n "$branch" ]; then
+    plutil -replace com-loopkit-Loop-git-branch -string "${branch}" "${info_plist_path}"
+  else
+    warn "No git branch found, not setting com-loopkit-Loop-git-branch"
+  fi
+fi
 
+plutil -replace com-loopkit-Loop-srcroot -string "${git_source_root}" "${info_plist_path}"
+plutil -replace com-loopkit-Loop-build-date -string "$(date)" "${info_plist_path}"
+plutil -replace com-loopkit-Loop-xcode-version -string "${xcode_build_version}" "${info_plist_path}"
+
+if [ -e "${provisioning_profile_path}" ]; then
+  profile_expire_date=$(security cms -D -i "${provisioning_profile_path}" | plutil -p - | grep ExpirationDate | cut -b 23-)
+  # Convert to plutil format
+  profile_expire_date=$(date -j -f "%Y-%m-%d %H:%M:%S" "${profile_expire_date}" +"%Y-%m-%dT%H:%M:%SZ")
+  plutil -replace com-loopkit-Loop-profile-expiration -date "${profile_expire_date}" "${info_plist_path}"
+else
+  warn "Invalid provisioning profile path ${provisioning_profile_path}"
+fi
+
+info "Added ${profile_expire_date} as profile expiration to ${info_plist_path}"

--- a/Settings.bundle/Root.plist
+++ b/Settings.bundle/Root.plist
@@ -14,7 +14,7 @@
 			<key>Key</key>
 			<string>adaptiveRateNonlinear_enabled</string>
 			<key>DefaultValue</key>
-			<true/>
+			<false/>
 		</dict>
 	</array>
 </dict>

--- a/WatchApp Extension/Info.plist
+++ b/WatchApp Extension/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>176</string>
+	<string>201</string>
 	<key>CLKComplicationPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
 	<key>CLKComplicationSupportedFamilies</key>

--- a/WatchApp/Info.plist
+++ b/WatchApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>176</string>
+	<string>201</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>com.loopkit.Loop.AddCarbEntryOnWatch</string>


### PR DESCRIPTION
The Loop and Learn team has taken on responsibility for the fork of Loop known as FreeAPS.

The build ID has been updated to FreeAPS v2.2 (201)

All builds 201 and higher are found the freeaps branch of the following 2 repositories:
* https://github.com/loopnlearn/LoopWorkspace
* https://github.com/loopnlearn/Loop

There may be work on-going in other branches that are only for testing, please do not use those branches without understanding the differences.

Aside from the change of the location of the fork, what is new for 201?

- Merged in the rileylink_ios improvements added in [Loop v2.2.5](https://loopkit.github.io/loopdocs/faqs/branch-faqs/#loop-v225) 
- The IOB accounting bug, which led to release of [Loop v2.2.6](https://loopkit.github.io/loopdocs/faqs/branch-faqs/#loop-v226) is not found in FreeAPS
- Accepted a PR to add Lyumjev insulin model
  - WARNING - if you select Lyumjev in FreeAPS and then build Loop over that app, the insulin model will say Tap to Set
- Accepted a PR to set the Adaptive Rate Nonlinear Model default value as OFF instead of ON
- Accepted a PR to include provisioning profile expiration date in Report (added in Loop v2.2.5)
  - The notification warning you of expiration was a little more complicated and is not included in this version
