### PR TITLE
Watchapp: reduce to two decimal places in bolus screen

### DIFF
--- a/WatchApp Extension/Controllers/BolusInterfaceController.swift
+++ b/WatchApp Extension/Controllers/BolusInterfaceController.swift
@@ -233,7 +233,7 @@ private extension BolusInterfaceController {
         case let bolus where bolus > 1:
             return Int((bolus - 1.0) * 20) + pickerValueFromBolusValue(1)
         default:
-            return Int(bolusValue * 40)
+            return Int(bolusValue * 20)
         }
     }
 
@@ -244,7 +244,7 @@ private extension BolusInterfaceController {
         case let picker where picker > 40:
             return Double(picker - 40) / 20.0 + bolusValueFromPickerValue(40)
         default:
-            return Double(pickerValue) / 40.0
+            return Double(pickerValue) / 20.0
         }
     }
 

--- a/WatchApp Extension/Extensions/NumberFormatter+WatchApp.swift
+++ b/WatchApp Extension/Extensions/NumberFormatter+WatchApp.swift
@@ -14,7 +14,7 @@ extension NumberFormatter {
     func string(fromBolusValue bolusValue: Double) -> String {
         switch bolusValue {
         case let x where x < 1:
-            minimumFractionDigits = 3
+            minimumFractionDigits = 2
         case let x where x < 10:
             minimumFractionDigits = 2
         default:


### PR DESCRIPTION
Remove the third decomal place from the watch bolus screen, and set the bolus increment to 0,05 U.

I hope this won't cause any issues, even for Medtronic users, where the minimum bolus is 0,025 U. That level of micromanagement is hopefully not needed for anyone.