### PR TITLE
Watch app commit. 

### DIFF
--- a/WatchApp/Base.lproj/Interface.storyboard
+++ b/WatchApp/Base.lproj/Interface.storyboard
@@ -174,6 +174,7 @@
                                                         </items>
                                                         <color key="backgroundColor" name="carbs-dark"/>
                                                         <variation key="device=watch38mm" height="54" radius="27" width="54"/>
+                                                        <variation key="device=watch41mm" height="54" radius="27" width="54"/>
                                                         <variation key="device=watch44mm" height="64" radius="32" width="64"/>
                                                     </group>
                                                     <connections>
@@ -196,6 +197,7 @@
                                                         </items>
                                                         <color key="backgroundColor" name="insulin-dark"/>
                                                         <variation key="device=watch38mm" height="54" radius="27" width="54"/>
+                                                        <variation key="device=watch41mm" height="54" radius="27" width="54"/>
                                                         <variation key="device=watch44mm" height="64" radius="32" width="64"/>
                                                     </group>
                                                     <connections>
@@ -222,7 +224,8 @@
                                                         </items>
                                                         <color key="backgroundColor" name="carbs-dark"/>
                                                         <variation key="device=watch38mm" height="54" radius="27" width="54"/>
-                                                        <variation key="device=watch44mm" height="64" radius="32" width="64"/>
+                                                        <variation key="device=watch41mm" height="54" radius="27" width="60"/>
+                                                        <variation key="device=watch44mm" height="54" radius="32" width="54"/>
                                                     </group>
                                                     <connections>
                                                         <action selector="togglePreMealMode" destination="rNf-Mh-tID" id="p9f-dP-MI2"/>
@@ -244,7 +247,8 @@
                                                         </items>
                                                         <color key="backgroundColor" name="workout-dark"/>
                                                         <variation key="device=watch38mm" height="54" radius="27" width="54"/>
-                                                        <variation key="device=watch44mm" height="64" radius="32" width="64"/>
+                                                        <variation key="device=watch41mm" height="54" radius="27" width="54"/>
+                                                        <variation key="device=watch44mm" height="54" radius="32" width="64"/>
                                                     </group>
                                                     <connections>
                                                         <action selector="toggleOverride" destination="rNf-Mh-tID" id="pMD-b9-FoF"/>

--- a/WatchApp/Base.lproj/Interface.storyboard
+++ b/WatchApp/Base.lproj/Interface.storyboard
@@ -224,7 +224,7 @@
                                                         </items>
                                                         <color key="backgroundColor" name="carbs-dark"/>
                                                         <variation key="device=watch38mm" height="54" radius="27" width="54"/>
-                                                        <variation key="device=watch41mm" height="54" radius="27" width="60"/>
+                                                        <variation key="device=watch41mm" height="54" radius="27" width="54"/>
                                                         <variation key="device=watch44mm" height="54" radius="32" width="54"/>
                                                     </group>
                                                     <connections>


### PR DESCRIPTION
Format 41 mm Loop Scene icons as 38 mm icons to avoid capping of icons on 41 mm watch (not tested on real watch yet). 